### PR TITLE
Refactors merics-server's update method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,7 @@ docker-build:
 
 .PHONY: maintenance
 maintenance: update-tools-versions update-actions
-	$(MAKE) -C ./e2e update-tools-version
-	$(MAKE) -C ./e2e/manifests/metrics-server update-manifests
+	$(MAKE) -C ./e2e maintenance
 
 .PHONY: update-tools-versions
 update-tools-versions: login-gh

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -83,6 +83,9 @@ $(KUBECTL): $(BIN_DIR)
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
+.PHONY: maintenance
+maintenance: update-tools-version update-pushgateway update-metrics-server
+
 .PHONY: update-tools-version
 update-tools-version: login-gh
 	$(call get-latest-gh,kubernetes-sigs/kind)
@@ -97,9 +100,16 @@ update-tools-version: login-gh
 	NEW_VERSION=$$(echo $(latest_gh) | cut -b 2-); \
 	sed -i -e "s/YQ_VERSION := .*/YQ_VERSION := $${NEW_VERSION}/g" Makefile.versions
 
+.PHONY: update-pushgateway
+update-pushgateway: login-gh
 	$(call get-latest-gh-package-tag,pushgateway)
 	NEW_VERSION=$$(echo $(latest_tag)); \
 	$(YQ) -i "(.images[] | select(.name==\"ghcr.io/cybozu/pushgateway\")).newTag = \"$(latest_tag)\"" manifests/pushgateway/kustomization.yaml
+
+.PHONY: update-metrics-server
+update-metrics-server: login-gh
+	curl -sSLf -o manifests/metrics-server/components.yaml \
+		https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 
 # usage get-latest-gh OWNER/REPO
 define get-latest-gh

--- a/e2e/manifests/metrics-server/Makefile
+++ b/e2e/manifests/metrics-server/Makefile
@@ -1,3 +1,0 @@
-.PHONY: update-manifests
-update-manifests:
-	https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml


### PR DESCRIPTION
This PR refactors merics-server's update method.

The makefile seems to be corrupted...
```
$ make maintenance 
...
make -C ./e2e/manifests/metrics-server update-manifests
make[1]: Entering directory '/home/user/go/src/github.com/cybozu-private/zombie-detector/e2e/manifests/metrics-server'
https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
make[1]: https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml: No such file or directory
make[1]: *** [Makefile:3: update-manifests] Error 127
make[1]: Leaving directory '/home/user/go/src/github.com/cybozu-private/zombie-detector/e2e/manifests/metrics-server'
make: *** [Makefile:42: maintenance] Error 2
```